### PR TITLE
iot-gateway: freeboard: update docker hub image path

### DIFF
--- a/iot-gateway.yml
+++ b/iot-gateway.yml
@@ -131,7 +131,7 @@
       backup=yes
   - name: Run freeboard container
     command: sh -c "docker stop freeboard; docker rm freeboard; "\
-                   "docker pull {{ hub|default('linarotechnologies') }}/freeboard-demo:{{ tag|default('latest') }}; "\
+                   "docker pull {{ hub|default('linarotechnologies') }}/freeboard:{{ tag|default('latest') }}; "\
                    "docker run --restart=always -d -t -p 80:80 "\
                            "-v /home/linaro/dashboard-private.json:/usr/share/nginx/html/dashboard.json "\
                            "--name freeboard {{ hub|default('linarotechnologies') }}/freeboard-demo:{{ tag|default('latest') }}"


### PR DESCRIPTION
Due to shuffling our 'extra' containers, some of the dockerhub image paths have changed, so lets update them.

https://trello.com/c/YyHCnOfN/80-jobserv-build-and-publish-extra-docker-containers

Signed-off-by: Tyler Baker <tyler.baker@linaro.org>